### PR TITLE
Configure environment variables via .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,19 @@
+# ----- Postgres -----
+POSTGRES_USER=leandro
+POSTGRES_PASSWORD=superseguro
+POSTGRES_DB=prueba_datos
+POSTGRES_PORT=5432
+
+# ----- Jupyter -----
+JUPYTER_TOKEN=tu_token_seguro
+
+# ----- Pipeline (conexión a Postgres) -----
+PIPELINE_DB_HOST=postgres
+PIPELINE_DB_PORT=5432
+PIPELINE_DB_NAME=prueba_datos
+PIPELINE_DB_USER=leandro
+PIPELINE_DB_PASSWORD=superseguro
+
+# ----- pgAdmin -----
+PGADMIN_DEFAULT_EMAIL=admin@example.com
+PGADMIN_DEFAULT_PASSWORD=admin123

--- a/README.md
+++ b/README.md
@@ -45,9 +45,11 @@ El comando `pipeline_pg.py load` ejecuta el pipeline en micro-batches usando `ps
 
 ## Configuración adicional
 
-* **Jupyter**: disponible en [http://localhost:8888](http://localhost:8888) con token `pipeline`. Trabaja sobre el directorio `notebooks/` y comparte datos en `/home/jovyan/data`.
-* **pgAdmin**: disponible en [http://localhost:8080](http://localhost:8080). Credenciales por defecto `admin@example.com` / `admin`. El archivo `pgadmin/servers.json` registra el servidor `local-postgres` (host `postgres`).
-* **Variables de entorno**: la aplicación usa `DATABASE_URL` y `PIPELINE_SOURCE_CSV` para definir conexión y origen de datos.
+Las credenciales y parámetros de conexión viven en el archivo `.env` (versionado) y son reutilizados por todos los servicios de Docker Compose. Puedes ajustarlos según tus necesidades antes de ejecutar `make up`.
+
+* **Jupyter**: disponible en [http://localhost:8888](http://localhost:8888) con token `tu_token_seguro`. Trabaja sobre el directorio `notebooks/` y comparte datos en `/home/jovyan/data`.
+* **pgAdmin**: disponible en [http://localhost:8080](http://localhost:8080). Credenciales por defecto `admin@example.com` / `admin123`. El archivo `pgadmin/servers.json` registra el servidor `local-postgres` (host `postgres`).
+* **Variables de entorno**: la aplicación usa `DATABASE_URL` y `PIPELINE_SOURCE_CSV` definidos en `docker-compose.yml`; `DATABASE_URL` se genera con los parámetros `PIPELINE_DB_*` declarados en `.env`.
 
 ## Estructura del repositorio
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,9 @@ services:
   postgres:
     image: postgres:16
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_DB: postgres
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
     ports:
       - "5432:5432"
     volumes:
@@ -15,7 +15,7 @@ services:
   app:
     build: ./app
     environment:
-      DATABASE_URL: postgresql://postgres:postgres@postgres:5432/postgres
+      DATABASE_URL: postgresql://${PIPELINE_DB_USER}:${PIPELINE_DB_PASSWORD}@${PIPELINE_DB_HOST}:${PIPELINE_DB_PORT}/${PIPELINE_DB_NAME}
       PIPELINE_SOURCE_CSV: /opt/pipeline/data/raw/events.csv
     volumes:
       - ./app:/opt/pipeline
@@ -26,7 +26,7 @@ services:
   jupyter:
     image: jupyter/minimal-notebook
     environment:
-      JUPYTER_TOKEN: pipeline
+      JUPYTER_TOKEN: ${JUPYTER_TOKEN}
     ports:
       - "8888:8888"
     command: start-notebook.sh --NotebookApp.default_url=/lab/tree/0_START_HERE.ipynb
@@ -39,8 +39,8 @@ services:
   pgadmin:
     image: dpage/pgadmin4
     environment:
-      PGADMIN_DEFAULT_EMAIL: admin@example.com
-      PGADMIN_DEFAULT_PASSWORD: admin
+      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL}
+      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD}
     ports:
       - "8080:80"
     volumes:


### PR DESCRIPTION
## Summary
- add a committed `.env` file with database, pgAdmin, and Jupyter credentials
- parameterize docker-compose services to read credentials from environment variables
- document the new environment file and credentials in the README

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dc0e82d5908333bc311aac61cb5482